### PR TITLE
Fix: Ensure all severity constants are imported and fix add_finding_f…

### DIFF
--- a/modules/environment_detection.py
+++ b/modules/environment_detection.py
@@ -12,7 +12,7 @@ import re
 import subprocess # Needed for direct call
 from modules.utils import (
     COLOR_GREEN, COLOR_RED, COLOR_YELLOW, COLOR_RESET,
-    SEVERITY_INFO, SEVERITY_MEDIUM,
+    SEVERITY_CRITICAL, SEVERITY_HIGH, SEVERITY_MEDIUM, SEVERITY_LOW, SEVERITY_INFO,
     run_command
 )
 

--- a/modules/file_system.py
+++ b/modules/file_system.py
@@ -10,7 +10,7 @@ import re
 import stat # For permission constants like S_IWOTH, S_ISUID, S_ISGID, S_ISVTX
 from modules.utils import (
     COLOR_GREEN, COLOR_RED, COLOR_YELLOW, COLOR_RESET,
-    SEVERITY_INFO, SEVERITY_LOW, SEVERITY_MEDIUM, SEVERITY_HIGH
+    SEVERITY_INFO, SEVERITY_LOW, SEVERITY_MEDIUM, SEVERITY_HIGH, SEVERITY_CRITICAL
 )
 
 # Paths to exclude from all recursive scans more reliably

--- a/modules/kernel_params.py
+++ b/modules/kernel_params.py
@@ -8,7 +8,7 @@ Guardian Module: Kernel Parameter Analysis (sysctl)
 import re
 from modules.utils import (
     COLOR_GREEN, COLOR_RED, COLOR_YELLOW, COLOR_RESET,
-    SEVERITY_INFO, SEVERITY_LOW, SEVERITY_MEDIUM, SEVERITY_HIGH,
+    SEVERITY_CRITICAL, SEVERITY_HIGH, SEVERITY_MEDIUM, SEVERITY_LOW, SEVERITY_INFO,
     run_command
 )
 

--- a/modules/log_analysis.py
+++ b/modules/log_analysis.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta # For time-based analysis (optional)
 
 from modules.utils import (
     COLOR_GREEN, COLOR_RED, COLOR_YELLOW, COLOR_RESET,
-    SEVERITY_INFO, SEVERITY_LOW, SEVERITY_MEDIUM, SEVERITY_HIGH
+    SEVERITY_CRITICAL, SEVERITY_HIGH, SEVERITY_MEDIUM, SEVERITY_LOW, SEVERITY_INFO
 )
 
 # --- Log Analysis Functions ---

--- a/modules/services_timers.py
+++ b/modules/services_timers.py
@@ -10,7 +10,7 @@ Checks systemd units for potential misconfigurations or risks.
 import re
 from modules.utils import (
     COLOR_GREEN, COLOR_RED, COLOR_YELLOW, COLOR_RESET,
-    SEVERITY_INFO, SEVERITY_LOW, SEVERITY_MEDIUM,
+    SEVERITY_CRITICAL, SEVERITY_HIGH, SEVERITY_MEDIUM, SEVERITY_LOW, SEVERITY_INFO,
     run_command
 )
 

--- a/modules/system_info.py
+++ b/modules/system_info.py
@@ -12,7 +12,10 @@ from datetime import datetime
 
 # Remove direct import of add_finding from guardian
 # from guardian import add_finding
-from modules.utils import SEVERITY_INFO, SEVERITY_HIGH, COLOR_RED, COLOR_RESET, COLOR_GREEN
+from modules.utils import (
+    COLOR_GREEN, COLOR_RED, COLOR_YELLOW, COLOR_RESET,
+    SEVERITY_CRITICAL, SEVERITY_HIGH, SEVERITY_MEDIUM, SEVERITY_LOW, SEVERITY_INFO
+)
 
 def get_system_info(managed_stats, managed_findings, add_finding_func):
     """


### PR DESCRIPTION
…unc calls

This commit addresses persistent NameErrors and other potential bugs by:

1.  **Correcting Specific NameErrors:**
    *   Added `SEVERITY_CRITICAL` to imports in `modules/file_system.py`.
    *   Added `SEVERITY_HIGH` (and other severities for standardization) to imports in `modules/services_timers.py`.

2.  **Standardizing Severity Imports:**
    *   Ensured all five severity constants (`SEVERITY_CRITICAL`, `SEVERITY_HIGH`, `SEVERITY_MEDIUM`, `SEVERITY_LOW`, `SEVERITY_INFO`) are imported in all modules that use any severity constant from `modules.utils.py`. This includes:
        *   `modules/environment_detection.py`
        *   `modules/kernel_params.py`
        *   `modules/log_analysis.py`
        *   `modules/process_analysis.py`
        *   `modules/system_info.py`

3.  **Correcting Function Call Arguments:**
    *   Fixed calls to `add_finding_func` within `modules/process_analysis.py` (in both `_analyze_connections` and `get_running_processes` functions) by removing the redundant `managed_findings` argument. The `add_finding_func` (which is `add_finding_mp`) already has access to `managed_findings`.

These changes should resolve the reported NameErrors and improve the overall robustness and maintainability of the program by ensuring consistent import practices.